### PR TITLE
Troubleshoot nginx proxy configuration issue

### DIFF
--- a/nginx-recovery-commands.sh
+++ b/nginx-recovery-commands.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+echo "🚨 Nginx 설정 복구 스크립트"
+echo "이 스크립트는 프테로닥틸 패널이 설치된 호스트 서버에서 실행하세요!"
+echo ""
+
+# 1. 현재 nginx 설정 백업
+echo "1️⃣ 현재 설정 백업 중..."
+sudo cp /etc/nginx/sites-available/teamwicked /etc/nginx/sites-available/teamwicked.backup.wrong 2>/dev/null
+sudo cp /etc/nginx/sites-available/default /etc/nginx/sites-available/default.backup 2>/dev/null
+
+# 2. 기존 프테로닥틸 설정 찾기
+echo "2️⃣ 기존 프테로닥틸 설정 찾는 중..."
+if [ -f "/etc/nginx/sites-available/pterodactyl.conf" ]; then
+    echo "✅ pterodactyl.conf 발견"
+    sudo cp /etc/nginx/sites-available/pterodactyl.conf /etc/nginx/sites-available/pterodactyl
+elif [ -f "/etc/nginx/sites-available/pterodactyl" ]; then
+    echo "✅ pterodactyl 설정 파일 존재"
+else
+    echo "⚠️  프테로닥틸 설정 파일이 없습니다. 새로 생성합니다..."
+    sudo cp /workspace/pterodactyl-panel-restore.conf /etc/nginx/sites-available/pterodactyl
+fi
+
+# 3. teamwicked 설정을 별도 파일로 분리
+echo "3️⃣ teamwicked.me 설정을 별도 파일로 생성..."
+sudo cp /workspace/teamwicked-nginx.conf /etc/nginx/sites-available/teamwicked
+
+# 4. 심볼릭 링크 재설정
+echo "4️⃣ 사이트 활성화..."
+sudo rm -f /etc/nginx/sites-enabled/teamwicked
+sudo rm -f /etc/nginx/sites-enabled/pterodactyl
+sudo ln -s /etc/nginx/sites-available/pterodactyl /etc/nginx/sites-enabled/
+sudo ln -s /etc/nginx/sites-available/teamwicked /etc/nginx/sites-enabled/
+
+# 5. nginx 테스트
+echo "5️⃣ Nginx 설정 테스트..."
+sudo nginx -t
+
+if [ $? -eq 0 ]; then
+    echo "✅ Nginx 설정이 올바릅니다. 재시작 중..."
+    sudo systemctl restart nginx
+    echo ""
+    echo "🎉 복구 완료!"
+    echo "- 프테로닥틸 패널: https://ingwannu.ggm.kr"
+    echo "- TeamWicked 사이트: http://teamwicked.me"
+else
+    echo "❌ Nginx 설정에 오류가 있습니다!"
+    echo "수동으로 확인이 필요합니다:"
+    echo "sudo nano /etc/nginx/sites-available/pterodactyl"
+    echo "sudo nano /etc/nginx/sites-available/teamwicked"
+fi
+
+# 6. 포트 확인
+echo ""
+echo "6️⃣ 포트 상태 확인..."
+sudo netstat -tlnp | grep -E "(80|443|50012)"

--- a/pterodactyl-panel-restore.conf
+++ b/pterodactyl-panel-restore.conf
@@ -1,0 +1,52 @@
+server {
+    listen 80;
+    server_name ingwannu.ggm.kr;
+    return 301 https://$server_name$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name ingwannu.ggm.kr;
+
+    root /var/www/pterodactyl/public;
+    index index.html index.htm index.php;
+    charset utf-8;
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log off;
+    error_log  /var/log/nginx/pterodactyl.app-error.log error;
+
+    # SSL configuration
+    ssl_certificate /etc/letsencrypt/live/ingwannu.ggm.kr/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/ingwannu.ggm.kr/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256';
+    ssl_prefer_server_ciphers on;
+
+    # PHP configuration
+    location ~ \.php$ {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass unix:/var/run/php/php8.1-fpm.sock;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param PHP_VALUE "upload_max_filesize = 100M \n post_max_size=100M";
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param HTTP_PROXY "";
+        fastcgi_intercept_errors off;
+        fastcgi_buffer_size 16k;
+        fastcgi_buffers 4 16k;
+        fastcgi_connect_timeout 300;
+        fastcgi_send_timeout 300;
+        fastcgi_read_timeout 300;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}

--- a/teamwicked-nginx.conf
+++ b/teamwicked-nginx.conf
@@ -1,0 +1,16 @@
+server {
+    listen 80;
+    server_name teamwicked.me www.teamwicked.me;
+
+    location / {
+        proxy_pass http://127.0.0.1:50012;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+}


### PR DESCRIPTION
Restore Pterodactyl Nginx configuration and add a separate Nginx configuration for teamwicked.me to fix panel access issues.

The user inadvertently overwrote the existing Pterodactyl panel Nginx configuration with a new site's configuration while attempting to set up a new domain, leading to the panel becoming inaccessible. This PR provides the necessary files and a recovery script to restore the Pterodactyl panel's Nginx configuration and correctly set up the new `teamwicked.me` site.

---
<a href="https://cursor.com/background-agent?bcId=bc-00febdfc-318f-4763-a44c-94717a73ff8b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-00febdfc-318f-4763-a44c-94717a73ff8b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

